### PR TITLE
Criar Middleware para tratar o Multi Language

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
  * @OA\Info(
  *      version="1.0.0",
  *      title="Yggdrasil API",
+ *      description="You can use X-localization (en or pt-br) header key to determine what language is used.",
  *      @OA\Contact(email="kayodw@gmail.com"),
  *      @OA\License(name="Apache 2.0", url="http://www.apache.org/licenses/LICENSE-2.0.html"),
  * )

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
         \Barryvdh\Cors\HandleCors::class,
+        \App\Http\Middleware\Localization::class,
     ];
 
     /**

--- a/app/Http/Middleware/Localization.php
+++ b/app/Http/Middleware/Localization.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class Localization
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $local = $request->hasHeader('X-localization') ? $request->header('X-localization') : 'pt-br';
+        app()->setLocale($local);
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Criar Middleware para tratar o Multi Language. É verificado se o
parâmetro "X-localization" foi enviado no header, caso não seja informado
o valor do idioma padrão será configurado.